### PR TITLE
Fix: Enumerate all Projects under a Group by using non-deprecated API

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -129,6 +129,12 @@ RESOURCES = {
         'key_properties': ['group_id', 'id'],
         'replication_method': 'FULL_TABLE',
     },
+    'group_projects': {
+        'url': '/groups/{id}/projects',
+        'schema': load_schema('group_projects'),
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+    },
     'releases': {
         'url': '/projects/{id}/releases',
         'schema': load_schema('releases'),
@@ -643,9 +649,10 @@ def sync_group(gid, pids):
 
     if not pids:
         #  Get all the projects of the group if none are provided
-        for project in data['projects']:
-            if project['id']:
-                sync_project(project['id'])
+        group_projects_url = get_url(entity="group_projects", id=gid)        
+        for project in gen_request(group_projects_url):
+            if project["id"]:
+                sync_project(project["id"])
     else:
         # Sync only specific projects of the group, if explicit projects are provided
         for pid in pids:

--- a/tap_gitlab/schemas/group_projects.json
+++ b/tap_gitlab/schemas/group_projects.json
@@ -1,0 +1,156 @@
+{
+    "type": "object",
+    "properties": {
+        "archived": {
+            "type": ["null", "boolean"]
+        },
+        "avatar_url": {
+            "type": ["null", "string"]
+        },
+        "created_at": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "creator_id": {
+            "type": ["null", "integer"]
+        },
+        "default_branch": {
+            "type": ["null", "string"]
+        },
+        "description": {
+            "type": ["null", "string"]
+        },
+        "forks_count": {
+            "type": ["null", "integer"]
+        },
+        "http_url_to_repo": {
+            "type": ["null", "string"]
+        },
+        "id": {
+            "type": ["null", "integer"]
+        },
+        "issues_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "jobs_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "last_activity_at": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "merge_requests_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "name": {
+            "type": ["null", "string"]
+        },
+        "name_with_namespace": {
+            "type": ["null", "string"]
+        },
+        "namespace": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": ["null", "integer"]
+                },
+                "kind": {
+                    "type": ["null", "string"]
+                },
+                "name": {
+                    "type": ["null", "string"]
+                },
+                "path": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "open_issues_count": {
+            "type": ["null", "integer"]
+        },
+        "path": {
+            "type": ["null", "string"]
+        },
+        "path_with_namespace": {
+            "type": ["null", "string"]
+        },
+        "public_jobs": {
+            "type": ["null", "boolean"]
+        },
+        "request_access_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "shared_runners_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "shared_with_groups": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "group_id": {
+                                "type": ["null", "integer"]
+                            },
+                            "group_name": {
+                                "type": ["null", "string"]
+                            },
+                            "group_access_level": {
+                                "type": ["null", "integer"]
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "snippets_enabled": {
+            "type": ["null", "boolean"]
+        },
+        "ssh_url_to_repo": {
+            "type": ["null", "string"]
+        },
+        "star_count": {
+            "type": ["null", "integer"]
+        },
+        "tag_list": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": ["null", "string"]
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "visibility": {
+            "type": ["null", "string"]
+        },
+        "web_url": {
+            "type": ["null", "string"]
+        },
+        "wiki_enabled": {
+            "type": ["null", "boolean"]
+        }
+    }
+}


### PR DESCRIPTION
This was merged from the gitlab mirror and never got migrated to this repo. https://gitlab.com/meltano/tap-gitlab/-/merge_requests/39.
