### PR TITLE
Load variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This tap:
   - [Epics](https://docs.gitlab.com/ee/api/epics.html) (only available for GitLab Ultimate and GitLab.com Gold accounts)
   - [Epic Issues](https://docs.gitlab.com/ee/api/epic_issues.html) (only available for GitLab Ultimate and GitLab.com Gold accounts)
   - [Vulnerabilities](https://docs.gitlab.com/ee/api/project_vulnerabilities.html)
+  - [Group Variables](https://docs.gitlab.com/ee/api/group_level_variables.html)
+  - [Project Variables](https://docs.gitlab.com/ee/api/project_level_variables.html)
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ pip install git+https://gitlab.com/meltano/tap-gitlab.git
       "start_date": "2018-01-01T00:00:00Z",
       "ultimate_license": true,
       "fetch_merge_request_commits": false,
-      "fetch_pipelines_extended": false
+      "fetch_pipelines_extended": false,
+      "fetch_group_variables": false,
+      "fetch_project_variables": false
     }
     ```
 
@@ -81,6 +83,10 @@ pip install git+https://gitlab.com/meltano/tap-gitlab.git
     If `fetch_merge_request_commits` is true (defaults to false), then for each Merge Request, also fetch the MR's commits and create the join table `merge_request_commits` with the Merge Request and related Commit IDs. In the current version of GitLab's API, this operation requires one API call per Merge Request, so setting this to True can slow down considerably the end-to-end extraction time. For example, in a project like `gitlab-org/gitlab-foss`, this would result to 15x more API calls than required for fetching all the other Entities supported by `tap-gitlab`.
 
     If `fetch_pipelines_extended` is true (defaults to false), then for every Pipeline fetched with `sync_pipelines` (which returns N pages containing all pipelines per project), also fetch extended details of each of these pipelines with `sync_pipelines_extended`. Similar concerns as those related to `fetch_merge_request_commits` apply here - every pipeline fetched with `sync_pipelines_extended` requires a separate API call.
+
+    If `fetch_group_variables` is true (defaults to false), then Group-level CI/CD variables will be retrieved for each available / specified group. This feature is treated as an opt-in to prevent users from accidentally extracting any potential secrets stored as Group-level CI/CD variables.
+
+    If `fetch_project_variables` is true (defaults to false), then Project-level CI/CD variables will be retrieved for each available / specified project. This feature is treated as an opt-in to prevent users from accidentally extracting any potential secrets stored as Project-level CI/CD variables.
 
 4. [Optional] Create the initial state file
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,8 @@ setup(name='tap-gitlab',
             "tags.json",
             "releases.json",
             "vulnerabilities.json",
+            "project_variables.json",
+            "group_variables.json"
           ],
       },
       include_package_data=True,

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -23,7 +23,9 @@ CONFIG = {
     'groups': '',
     'ultimate_license': False,
     'fetch_merge_request_commits': False,
-    'fetch_pipelines_extended': False
+    'fetch_pipelines_extended': False,
+    'fetch_group_variables': False,
+    'fetch_project_variables': False
 }
 STATE = {}
 CATALOG = None
@@ -206,7 +208,12 @@ RESOURCES = {
 }
 
 ULTIMATE_RESOURCES = ("epics", "epic_issues")
-STREAM_CONFIG_SWITCHES = ('merge_request_commits', 'pipelines_extended')
+STREAM_CONFIG_SWITCHES = (
+    'merge_request_commits',
+    'pipelines_extended',
+    'group_variables',
+    'project_variables',
+)
 
 LOGGER = singer.get_logger()
 SESSION = requests.Session()
@@ -921,6 +928,8 @@ def main_impl():
     CONFIG['ultimate_license'] = truthy(CONFIG['ultimate_license'])
     CONFIG['fetch_merge_request_commits'] = truthy(CONFIG['fetch_merge_request_commits'])
     CONFIG['fetch_pipelines_extended'] = truthy(CONFIG['fetch_pipelines_extended'])
+    CONFIG['fetch_group_variables'] = truthy(CONFIG['fetch_group_variables'])
+    CONFIG['fetch_project_variables'] = truthy(CONFIG['fetch_project_variables'])
 
     if '/api/' not in CONFIG['api_url']:
         CONFIG['api_url'] += '/api/v4'

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -25,7 +25,7 @@ CONFIG = {
     'fetch_merge_request_commits': False,
     'fetch_pipelines_extended': False,
     'fetch_group_variables': False,
-    'fetch_project_variables': False
+    'fetch_project_variables': False,
 }
 STATE = {}
 CATALOG = None
@@ -197,13 +197,13 @@ RESOURCES = {
         'url': '/projects/{id}/variables',
         'schema': load_schema('project_variables'),
         'key_properties': ['project_id', 'key'],
-        'replication_method': 'FULL_TABLE'
+        'replication_method': 'FULL_TABLE',
     },
     'group_variables': {
         'url': '/groups/{id}/variables',
         'schema': load_schema('group_variables'),
         'key_properties': ['group_id', 'key'],
-        'replication_method': 'FULL_TABLE'
+        'replication_method': 'FULL_TABLE',
     }
 }
 

--- a/tap_gitlab/schemas/group_variables.json
+++ b/tap_gitlab/schemas/group_variables.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "properties": {
+        "group_id": {
+            "type": ["null", "integer"]
+        },
+        "variable_type": {
+            "type": ["null", "string"]
+        },
+        "key": {
+            "type": ["null", "string"]
+        },
+        "value": {
+            "type": ["null", "string"]
+        },
+        "protected": {
+            "type": ["null", "boolean"]
+        },
+        "masked": {
+            "type": ["null", "boolean"]
+        },
+        "environment_scope": {
+            "type": ["null", "string"]
+        }
+    }
+}

--- a/tap_gitlab/schemas/project_variables.json
+++ b/tap_gitlab/schemas/project_variables.json
@@ -1,0 +1,26 @@
+{
+    "type": "object",
+    "properties": {
+        "project_id": {
+            "type": ["null", "integer"]
+        },
+        "variable_type": {
+            "type": ["null", "string"]
+        },
+        "key": {
+            "type": ["null", "string"]
+        },
+        "value": {
+            "type": ["null", "string"]
+        },
+        "protected": {
+            "type": ["null", "boolean"]
+        },
+        "masked": {
+            "type": ["null", "boolean"]
+        },
+        "environment_scope": {
+            "type": ["null", "string"]
+        }
+    }
+}


### PR DESCRIPTION
# How was this code tested?
This code was tested locally with a `meltano.yml` file to the effect of:
(note, some fields are redacted or replaced with meaningless values for privacy)
```
version: 1
send_anonymous_usage_stats: true
project_id: ***
plugins:
  extractors:
  - name: tap-gitlab
    pip_url: git+https://github.com/wersly/tap-gitlab.git@load-variables
    config:
      api_url: ***
      private_token: ***
      groups: some/group
      projects: some/group/project
      start_date: '1970-01-01T00:00:00Z'
      ultimate_license: true
      fetch_merge_request_commits: false
      fetch_pipelines_extended: false
    capabilities:
    - state
    - catalog
    - discover
  loaders:
  - name: target-bigquery
    variant: adswerve
    config:
      project_id: foo
      dataset_id: bar
      location: ***
      validate_records: true
      add_metadata_columns: true
      replication_method: truncate
      table_prefix: some_prefix_
  - name: target-jsonl
    variant: andyh1203
    config:
      destination_path: output
      do_timestamp_file: true
  - name: target-sqlite
    variant: meltanolabs
    pip_url: git+https://github.com/MeltanoLabs/target-sqlite.git
    config:
      database: foo.db
  transformers:
  - name: dbt
    pip_url: 'dbt-core~=1.0.0 dbt-postgres~=1.0.0 dbt-redshift~=1.0.0 dbt-snowflake~=1.0.0
      dbt-bigquery~=1.0.0

      '
    config:
      target: big-query
  files:
  - name: dbt
    pip_url: git+https://gitlab.com/meltano/files-dbt.git@config-version-2
environments:
- name: dev
  config:
    plugins:
      extractors:
      - name: tap-gitlab
        select:
        - project_variables.*
        - group_variables.*
```
And the following meltano operations were performed:
```
1. meltano elt tap-gitlab target-jsonl
2. meltano elt tap-gitlab target-sqlite
3. meltano elt tap-gitlab target-bigquery
4. meltano elt tap-gitlab target-bigquery --transform run
```
In all cases, the project_variables and group_variables were loaded to their targets with the provided schemas. In the case of interactions with databases (sqlite, bigquery) tables were appropriately truncated per the default replication methods for project_variables and group_variables when meltano operations were performed multiple times. Likewise, dbt was able to run on the data without regression.

Please let me know if there are any additional tests or modifications you'd like me to run on this.

# Risks, Tradeoffs, Backwards Compatibility Issues
None that I can really see. The `sync_variables` function is essentially a copy-paste from the `sync_labels` function (very similar pattern in the GitLab API between Group/Project labels and Group/Project variables), so any risks assumed there are also assumed here. 

While it is not a tradeoff, I would like to point out the `key_properties` I've selected for the group and project variables - the GitLab API does not assign any sort of `id` field to these data. So instead, the project/group id (assigned by the `sync_variables` function) and the `key` (from GitLab) are taken together to form a compound key. Variable `key`s must be unique within GitLab CI/CD Variables for a single Project or Group, but of course they can be duplicated across Projects/Groups. So the combination of Group/Project ID and variable `key` seems like the correct natural key for this data to me.

See:
- https://docs.gitlab.com/ee/api/project_level_variables.html#list-project-variables
- https://docs.gitlab.com/ee/api/group_level_variables.html#list-group-variables