### PR TITLE
Fix so this runs in the meltano demo project

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -38,12 +38,6 @@ jobs:
       TAP_GITLAB_PRIVATE_TOKEN: ${{secrets.GITLAB_PRIVATE_TOKEN}}
       TAP_GITLAB_GROUPS: meltano/infra
       TAP_GITLAB_PROJECTS: meltano/demo-project
-      TAP_GITLAB_ULTIMATE_LICENSE: false
-      TAP_GITLAB_FETCH_MERGE_REQUEST_COMMITS: false
-      TAP_GITLAB_FETCH_PIPELINES_EXTENDED: false
-      TAP_GITLAB_FETCH_GROUP_VARIABLES: false
-      TAP_GITLAB_FETCH_SITE_USERS: false
-      TAP_GITLAB_FETCH_PROJECT_VARIABLES: false
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Secrets and internal config files
 **/.secrets/*
 
+# API cache
+api_caches
+
 # Ignore meltano internal cache and sqlite systemdb
 .meltano/
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Built with the [Meltano SDK](https://sdk.meltano.com) for Singer Taps and Target
 
 | Setting                    | Required | Default | Description |
 |:---------------------------|:--------:|:-------:|:------------|
-| api_url                    | False    | None    | Optionally overrides the default base URL for the Gitlab API. |
+| api_url                    | False    | None    | Optionally overrides the default base URL for the Gitlab API. If no path is provided, the base URL will be appended with `/api/v4`. E.g. 'https://gitlab.com' becomes 'https://gitlab.com/api/v4'. |
 | private_token              | True     | None    | An access token to use when calling to the Gitlab API. |
 | groups                     | False    | None    | A space delimited list of group ids, e.g. 'orgname1 orgname2 orgname3' |
 | projects                   | False    | None    | A space delimited list of project ids, e.g. 'orgname/projectname1 orgname/projectname2 |

--- a/meltano.yml
+++ b/meltano.yml
@@ -1,6 +1,6 @@
 version: 1
 send_anonymous_usage_stats: true
-project_id: tap-gitlab
+project_id: tap-gitlab--meltanolabs
 plugins:
   extractors:
   - name: tap-gitlab
@@ -12,11 +12,7 @@ plugins:
     - discover
     - about
     - stream-maps
-    - schema-flattening
-    config:
-      start_date: '2010-01-01T00:00:00Z'
     settings:
-    # TODO: To configure using Meltano, declare settings and their types here:
     - name: api_url
       kind: string
     - name: private_token
@@ -45,7 +41,10 @@ plugins:
       kind: boolean
     - name: flattening_max_depth
       kind: integer
-    
+    - name: requests_cache_path
+      kind: string
+    config:
+      start_date: '2010-01-01T00:00:00Z'
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -44,12 +44,13 @@ plugins:
     - name: requests_cache_path
       kind: string
     config:
-      projects: meltano/demo-project
+      projects: meltano/demo-project meltano/meltano
       start_date: '2022-03-01T00:00:00Z'
       requests_cache_path: ./api_caches
     select:
-    - "*.*"
-    - "!jobs"  # very slow
+    - '*.*'
+    - '!jobs'                 # Very slow
+    - '!pipelines_extended'   # Very slow
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/meltano.yml
+++ b/meltano.yml
@@ -44,8 +44,16 @@ plugins:
     - name: requests_cache_path
       kind: string
     config:
-      start_date: '2010-01-01T00:00:00Z'
+      projects: meltano/demo-project
+      start_date: '2022-03-01T00:00:00Z'
+      requests_cache_path: ./api_caches
+    select:
+    - "*.*"
+    - "!jobs"  # very slow
   loaders:
   - name: target-jsonl
     variant: andyh1203
     pip_url: target-jsonl
+  - name: target-sqlite
+    variant: meltanolabs
+    pip_url: git+https://github.com/MeltanoLabs/target-sqlite.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-gitlab"
-version = "0.0.1"
+version = "2.0.0-alpha3"
 description = "`tap-gitlab` is a Singer tap for GitLab, built with the Meltano SDK for Singer Taps."
 authors = ["Meltano and Meltano Community"]
 keywords = [

--- a/tap_gitlab/caching.py
+++ b/tap_gitlab/caching.py
@@ -14,6 +14,7 @@ def setup_requests_cache(tap_config: dict, logger: logging.Logger) -> None:
     if not cache_path_root:
         return
 
+    num_files = 0
     if os.path.exists(cache_path_root):
         num_files = len(os.listdir(cache_path_root))
 

--- a/tap_gitlab/caching.py
+++ b/tap_gitlab/caching.py
@@ -1,6 +1,7 @@
 """Test suite for tap-github."""
 
 import logging
+import os
 
 import requests_cache
 
@@ -13,7 +14,13 @@ def setup_requests_cache(tap_config: dict, logger: logging.Logger) -> None:
     if not cache_path_root:
         return
 
-    logger.info(f"Request caching is enabled at: {cache_path_root}")
+    if os.path.exists(cache_path_root):
+        num_files = len(os.listdir(cache_path_root))
+
+    logger.info(
+        f"Request caching is enabled at '{cache_path_root}'. "
+        f"Found {num_files:,} cache resources during setup."
+    )
 
     requests_cache.install_cache(
         cache_path_root,

--- a/tap_gitlab/caching.py
+++ b/tap_gitlab/caching.py
@@ -1,18 +1,19 @@
 """Test suite for tap-github."""
 
+import logging
+
 import requests_cache
 
 from tap_gitlab.client import API_TOKEN_KEY
 
 
-def setup_requests_cache(tap_config: dict) -> None:
+def setup_requests_cache(tap_config: dict, logger: logging.Logger) -> None:
     """Install the caching mechanism for requests."""
     cache_path_root = tap_config.get("requests_cache_path", None)
     if not cache_path_root:
-        return None
+        return
 
-    # recording = tap_config.get("requests_recording_enabled", False)
-    # TODO: leverage `recording` to enable/disable the below
+    logger.info(f"Request caching is enabled at: {cache_path_root}")
 
     requests_cache.install_cache(
         cache_path_root,

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -7,6 +7,7 @@ import urllib
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union, cast
+from urllib.parse import urlparse
 
 import requests
 from singer_sdk.authenticators import APIKeyAuthenticator
@@ -41,9 +42,12 @@ class GitLabStream(RESTStream):
         'https://gitlab.com` is equivalent to 'https://gitlab.com/' and
         'https://gitlab.com/api/v4' is equivalent to 'https://gitlab.com/api/v4/'.
         """
+        # Remove trailing '/' from url base.
         result = self.config.get("api_url", DEFAULT_API_URL).rstrip("/")
-        if "/" not in result.replace("://", ""):
-            # If not path part is provided, append the v4 endpoint info.
+
+        # If path part is not provided, append the v4 endpoint as default:
+        # For example 'https://gitlab.com' => 'https://gitlab.com/api/v4'
+        if not urlparse(result).path:
             result += "/api/v4"
         return result
 

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -30,8 +30,16 @@ class GitLabStream(RESTStream):
 
     @property
     def url_base(self) -> str:
-        """Return the API URL root, configurable via tap settings."""
-        return self.config.get("api_url", DEFAULT_API_URL)
+        """Return the API URL root, configurable via tap settings.
+
+        If no path is provided, the base URL will be appended with `/api/v4`.
+        E.g. 'https://gitlab.com' would become 'https://gitlab.com/api/v4'
+        """
+        result = self.config.get("api_url", DEFAULT_API_URL)
+        if "/" not in result.replace("://", ""):
+            # If not path part is provided, append the v4 endpoint info.
+            result += "/api/v4"
+        return result
 
     @property
     def schema_filename(self) -> str:

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -76,7 +76,8 @@ class GitLabStream(RESTStream):
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         # If the class has extra default params, start with those:
-        params: dict = self.extra_url_params
+        # TODO: SDK Bug: without copy(), this will leak params across classes/objects.
+        params: dict = copy.copy(self.extra_url_params)
 
         if next_page_token:
             params["page"] = next_page_token

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -36,8 +36,12 @@ class GitLabStream(RESTStream):
 
         If no path is provided, the base URL will be appended with `/api/v4`.
         E.g. 'https://gitlab.com' would become 'https://gitlab.com/api/v4'
+
+        Note: trailing slashes ('/') are scrubbed prior to comparison, so that
+        'https://gitlab.com` is equivalent to 'https://gitlab.com/' and
+        'https://gitlab.com/api/v4' is equivalent to 'https://gitlab.com/api/v4/'.
         """
-        result = self.config.get("api_url", DEFAULT_API_URL)
+        result = self.config.get("api_url", DEFAULT_API_URL).rstrip("/")
         if "/" not in result.replace("://", ""):
             # If not path part is provided, append the v4 endpoint info.
             result += "/api/v4"

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -132,7 +132,7 @@ class GitLabStream(RESTStream):
         if result is None:
             return None
 
-        assert context is not None  # All streams have parent or partitions
+        assert context is not None  # Tell linter that context is non-null
 
         for key, val in context.items():
             if key in self.schema.get("properties", {}) and key not in result:

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -86,27 +86,11 @@ class GitLabStream(RESTStream):
 
     @staticmethod
     def _url_encode(val: Union[str, datetime, bool, int, List[str]]) -> str:
-        """Encode the val argument as url-compatible string.
-
-        Args:
-            val: TODO
-
-        Returns:
-            TODO
-        """
+        """Encode the val argument as url-compatible string."""
         return urllib.parse.quote_plus(str(val))
 
     def get_url(self, context: Optional[dict]) -> str:
-        """Get stream entity URL.
-
-        Developers override this method to perform dynamic URL generation.
-
-        Args:
-            context: Stream partition or context dictionary.
-
-        Returns:
-            A URL, optionally targeted to a specific partition or context.
-        """
+        """Get stream entity URL."""
         url = "".join([self.url_base, self.path or ""])
         vals = copy.copy(dict(self.config))
         vals.update(context or {})

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -27,6 +27,8 @@ class GitLabStream(RESTStream):
     next_page_token_jsonpath = "$.X-Next-Page"
     extra_url_params: dict = {}
     bookmark_param_name = "since"
+    _LOG_REQUEST_METRIC_URLS = True  # Okay to print in logs
+    # sensitive_request_path = False  # TODO: Update SDK to accept this instead.
 
     @property
     def url_base(self) -> str:

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -87,27 +87,6 @@ class ProjectBasedStream(GitLabStream):
 
     state_partitioning_keys = ["project_path"]
 
-    @property
-    def partitions(self) -> List[dict]:
-        """Return a list of partition key dicts (if applicable), otherwise None."""
-        if "{project_path}" in self.path:
-            if "projects" not in self.config:
-                raise ValueError(
-                    f"Missing `projects` setting which is required for the "
-                    f"'{self.name}' stream."
-                )
-
-            return [
-                {"project_path": id}
-                for id in cast(list, self.config["projects"].split(" "))
-            ]
-
-        raise ValueError(
-            "Could not detect partition type for Gitlab stream "
-            f"'{self.name}' ({self.path}). "
-            "Expected a URL path containing '{project_path}' or '{group_path}'. "
-        )
-
 
 class GroupBasedStream(GitLabStream):
     """Base class for streams that are keys based on group ID."""

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -177,7 +177,6 @@ class PipelinesExtendedStream(ProjectBasedStream):
     """Gitlab extended Pipelines stream."""
 
     name = "pipelines_extended"
-    parent_stream_type = ProjectsStream
     path = "/projects/{project_id}/pipelines/{pipeline_id}"
     primary_keys = ["id"]
     parent_stream_type = PipelinesStream
@@ -187,7 +186,6 @@ class PipelineJobsStream(ProjectBasedStream):
     """Gitlab Pipeline Jobs stream."""
 
     name = "jobs"
-    parent_stream_type = ProjectsStream
     path = "/projects/{project_id}/pipelines/{pipeline_id}/jobs"
     primary_keys = ["id"]
     parent_stream_type = PipelinesStream  # Stream should wait for parents to complete.

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -48,7 +48,7 @@ class ProjectsStream(ProjectBasedStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Perform post processing, including queuing up any child stream types."""
-        assert context is not None
+        assert context is not None  # Tell linter that context is non-null
         return {
             "project_id": record["id"],
             "project_path": context["project_path"],
@@ -115,7 +115,7 @@ class ProjectMergeRequestsStream(ProjectBasedStream):
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Perform post processing, including queuing up any child stream types."""
         # Ensure child state record(s) are created
-        assert context is not None
+        assert context is not None  # Tell linter that context is non-null
         return {
             "project_path": context["project_path"],
             "project_id": record["project_id"],
@@ -173,7 +173,7 @@ class BranchesStream(ProjectBasedStream):
         if result is None:
             return None
 
-        assert context is not None
+        assert context is not None  # Tell linter that context is non-null
 
         result["project_id"] = context["project_id"]
         result["commit_id"] = pop_nested_id(result, "commit")
@@ -283,8 +283,7 @@ class GroupsStream(GroupBasedStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Perform post processing, including queuing up any child stream types."""
-        # Ensure child state record(s) are created
-        assert context is not None
+        assert context is not None  # Tell linter that context is non-null
         return {
             "group_path": context["group_path"],
             "group_id": record["id"],

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -367,22 +367,20 @@ class GlobalSiteUsersStream(GitLabStream):
     schema_filename = "users.json"
 
 
-# TODO: Failing with:
-# FatalAPIError: 400 Client Error: Bad Request for path:
-# /projects/{project_path}/releases
-# class ReleasesStream(ProjectBasedStream):
-#     """Gitlab Releases stream."""
+class TagsStream(ProjectBasedStream):
+    """Gitlab Tags stream."""
 
-#     name = "releases"
-#     path = "/projects/{project_path}/releases"
-#     primary_keys = ["project_id", "commit_id", "tag_name"]
-#     replication_key = None
+    name = "tags"
+    path = "/projects/{project_path}/repository/tags"
+    primary_keys = ["project_id", "commit_id", "name"]
+    parent_stream_type = ProjectsStream
 
 
-# TODO: Failing with:
-# FatalAPIError: 400 Client Error: Bad Request for path:
-# /projects/{project_path}/repository/tags
-# class TagsStream(ProjectBasedStream):
-#     name = "tags"
-#     path = "/projects/{project_path}/repository/tags"
-#     primary_keys = ["project_id", "commit_id", "name"]
+class ReleasesStream(ProjectBasedStream):
+    """Gitlab Releases stream."""
+
+    name = "releases"
+    path = "/projects/{project_path}/releases"
+    primary_keys = ["project_id", "commit_id", "tag_name"]
+    replication_key = None
+    parent_stream_type = ProjectsStream

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -129,7 +129,7 @@ class MergeRequestCommitsStream(ProjectBasedStream):
     """Gitlab Commits stream."""
 
     name = "merge_request_commits"
-    path = "/projects/{project_id}/merge_requests/{merge_request_id}/commits"
+    path = "/projects/{project_id}/merge_requests/{merge_request_iid}/commits"
     primary_keys = ["project_id", "merge_request_iid", "commit_id"]
     parent_stream_type = ProjectMergeRequestsStream
 

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -61,12 +61,13 @@ class IssuesStream(ProjectBasedStream):
     """Gitlab Issues stream."""
 
     name = "issues"
-    parent_stream_type = ProjectsStream
     path = "/projects/{project_id}/issues"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    bookmark_param_name = "updated_after"
     is_sorted = True
+    parent_stream_type = ProjectsStream
+
+    bookmark_param_name = "updated_after"
     extra_url_params = {"scope": "all"}
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
@@ -83,10 +84,11 @@ class ProjectMergeRequestsStream(ProjectBasedStream):
     """Gitlab Merge Requests stream."""
 
     name = "merge_requests"
-    parent_stream_type = ProjectsStream
     path = "/projects/{project_id}/merge_requests"
     primary_keys = ["id"]
     replication_key = "updated_at"
+    parent_stream_type = ProjectsStream
+
     bookmark_param_name = "updated_after"
     extra_url_params = {"scope": "all"}
 
@@ -127,11 +129,12 @@ class CommitsStream(ProjectBasedStream):
     """Gitlab Commits stream."""
 
     name = "commits"
-    parent_stream_type = ProjectsStream
     path = "/projects/{project_id}/repository/commits"
     primary_keys = ["id"]
     replication_key = "created_at"
     is_sorted = False
+    parent_stream_type = ProjectsStream
+
     extra_url_params = {"with_stats": "true"}
 
 
@@ -163,8 +166,9 @@ class PipelinesStream(ProjectBasedStream):
     path = "/projects/{project_id}/pipelines"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    bookmark_param_name = "updated_after"
     parent_stream_type = ProjectsStream
+
+    bookmark_param_name = "updated_after"
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Perform post processing, including queuing up any child stream types."""

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -141,7 +141,6 @@ class BranchesStream(ProjectBasedStream):
     name = "branches"
     path = "/projects/{project_id}/repository/branches"
     primary_keys = ["project_id", "name"]
-    # TODO: Research why this fails:
     parent_stream_type = ProjectsStream
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
@@ -152,8 +151,7 @@ class BranchesStream(ProjectBasedStream):
 
         assert context is not None
 
-        # TODO: Uncomment when parent relationship works
-        # result["project_id"] = context["project_id"]
+        result["project_id"] = context["project_id"]
         result["commit_id"] = pop_nested_id(result, "commit")
         return result
 

--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -396,6 +396,15 @@ class TagsStream(ProjectBasedStream):
     primary_keys = ["project_id", "commit_id", "name"]
     parent_stream_type = ProjectsStream
 
+    def post_process(self, row: dict, context: Optional[dict] = None) -> Optional[dict]:
+        """Post process records."""
+        result = super().post_process(row, context)
+        if result is None:
+            return None
+
+        result["commit_id"] = result.pop("commit")["id"]
+        return result
+
 
 class ReleasesStream(ProjectBasedStream):
     """Gitlab Releases stream."""

--- a/tap_gitlab/tap.py
+++ b/tap_gitlab/tap.py
@@ -31,7 +31,11 @@ class TapGitLab(Tap):
             "api_url",
             th.StringType,
             required=False,
-            description="Optionally overrides the default base URL for the Gitlab API.",
+            description=(
+                "Optionally overrides the default base URL for the Gitlab API. "
+                "If no path is provided, the base URL will be appended with `/api/v4`. "
+                "E.g. 'https://gitlab.com' becomes 'https://gitlab.com/api/v4'."
+            ),
         ),
         th.Property(
             "private_token",

--- a/tap_gitlab/tap.py
+++ b/tap_gitlab/tap.py
@@ -148,7 +148,7 @@ class TapGitLab(Tap):
         If any streams are disabled in settings, they will not be exposed here during
         discovery.
         """
-        setup_requests_cache(dict(self.config))
+        setup_requests_cache(dict(self.config), self.logger)
 
         stream_types: List[type] = []
         for _, module_class in inspect.getmembers(streams, inspect.isclass):

--- a/tap_gitlab/tests/test_core.py
+++ b/tap_gitlab/tests/test_core.py
@@ -12,8 +12,9 @@ load_dotenv()  # Import any environment variables from local `.env` file.
 
 PREFIX = "TAP_GITLAB_"
 SAMPLE_CONFIG: Dict[str, Any] = {
-    "start_date": "2022-03-01T00:00:00Z",
+    # To improve test performance, optionally bump date forward or use a dynamic date:
     # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "start_date": "2022-03-01T00:00:00Z",
     "private_token": os.getenv("TAP_GITLAB_PRIVATE_TOKEN"),
     "projects": os.getenv("TAP_GITLAB_PROJECTS", "meltano/demo-project"),
     "groups": os.getenv("TAP_GITLAB_GROUPS", "meltano/infra"),

--- a/tap_gitlab/tests/test_core.py
+++ b/tap_gitlab/tests/test_core.py
@@ -1,6 +1,5 @@
 """Tests standard tap features using the built-in SDK tests library."""
 
-import datetime
 import os
 from typing import Any, Dict
 

--- a/tap_gitlab/tests/test_core.py
+++ b/tap_gitlab/tests/test_core.py
@@ -13,7 +13,8 @@ load_dotenv()  # Import any environment variables from local `.env` file.
 
 PREFIX = "TAP_GITLAB_"
 SAMPLE_CONFIG: Dict[str, Any] = {
-    "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+    "start_date": "2022-03-01T00:00:00Z",
+    # "start_date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
     "private_token": os.getenv("TAP_GITLAB_PRIVATE_TOKEN"),
     "projects": os.getenv("TAP_GITLAB_PROJECTS", "meltano/demo-project"),
     "groups": os.getenv("TAP_GITLAB_GROUPS", "meltano/infra"),


### PR DESCRIPTION
This addresses the issues causing the demo project to fail. 

What I found was that we were using project_path and group_path for the endpoints. The docs (at least for a few of the endpoints) say you can use project_id or an _escaped_ version of the project name/path - with some endpoints seeming to to inconsistently be bothers if `/` in a project path like `meltano/meltano` is escaped.

Some endpoints that were failing for me before would succeed if I swapped out the project or group path for the ID. 

Related to: https://gitlab.com/meltano/demo-project/-/merge_requests/17
which is being worked on in parallel