### PR TITLE
Add option to 'ignore_access_denied'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Built with the [Meltano SDK](https://sdk.meltano.com) for Singer Taps and Target
 | stream_map_config          | False    | None    | User-defined config values to be used within map expressions. |
 | flattening_enabled         | False    | None    | 'True' to enable schema flattening and automatically expand nested properties. |
 | flattening_max_depth       | False    | None    | The max depth to flatten schemas. |
+| ignore_access_denied       | False    | False   | True to ignore access denied (HTTP 401) errors. This option is provided for compatibility with prior versions of this tap, which would silently move on to the next stream after receiving an access denied error. If 'False', the tap will fail if access denied errors are received for any selected streams. |
 
 A full list of supported settings and capabilities is available by running: `tap-gitlab --about`
 

--- a/tap_gitlab/client.py
+++ b/tap_gitlab/client.py
@@ -140,6 +140,34 @@ class GitLabStream(RESTStream):
 
         return result
 
+    def validate_response(self, response: requests.Response) -> None:
+        """Validate HTTP response.
+
+        Overrides the base class in order to ignore 401 access denied errors if the
+        config value 'ignore_access_denied' is True.
+
+        Args:
+            response: A `requests.Response`_ object.
+
+        Raises:
+            FatalAPIError: If the request is not retriable.
+            RetriableAPIError: If the request is retriable.
+
+        .. _requests.Response:
+            https://docs.python-requests.org/en/latest/api/#requests.Response
+        """
+        if (
+            self.config.get("ignore_access_denied", False)
+            and response.status_code == 401
+        ):
+            self.logger.info(
+                "Ignoring 401 access denied error "
+                "('ignore_access_denied' setting is True)."
+            )
+            return
+
+        super().validate_response(response)
+
 
 class ProjectBasedStream(GitLabStream):
     """Base class for streams that are keys based on project ID."""

--- a/tap_gitlab/tap.py
+++ b/tap_gitlab/tap.py
@@ -138,6 +138,19 @@ class TapGitLab(Tap):
                 "recorded to this path as it is received."
             ),
         ),
+        th.Property(
+            "ignore_access_denied",
+            th.StringType,
+            required=False,
+            default=False,
+            description=(
+                "True to ignore access denied (HTTP 401) errors. This option is "
+                "provided for compatibility with prior versions of this tap, which "
+                "would silently move on to the next stream after receiving an access "
+                "denied error. If 'False', the tap will fail if access denied errors "
+                "are received for any selected streams."
+            ),
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
This PR adds a new 'ignore_access_denied' setting for compatibility with the older version of this repo.

> True to ignore access denied (HTTP 401) errors. This option is provided for compatibility with prior versions of this tap, which would silently move on to the next stream after receiving an access denied error. If 'False', the tap will fail if access denied errors are received for any selected streams.