### PR TITLE
feat: Add `ci_config_path` to projects schema

### DIFF
--- a/tap_gitlab/streams.py
+++ b/tap_gitlab/streams.py
@@ -191,6 +191,7 @@ class ProjectsStream(ProjectBasedStream):
         th.Property("snippets_enabled", th.BooleanType),
         th.Property("wiki_enabled", th.BooleanType),
         th.Property("license_url", th.StringType),
+        th.Property("ci_config_path", th.StringType),
         th.Property(
             "license",
             th.ObjectType(


### PR DESCRIPTION
Ported from https://github.com/MeltanoLabs/tap-gitlab/pull/97