### PR TITLE
feat: add on_predicate decorator to handle 429

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -248,7 +248,11 @@ def get_start(entity):
         STATE[entity] = CONFIG['start_date']
     return STATE[entity]
 
-@backoff.on_predicate(backoff.runtime,  predicate=lambda r: r.status_code == 429, vale=lambda r: int(r.headers.get("Retry-After")), jitter=None)
+@backoff.on_predicate(backoff.runtime,
+                      predicate=lambda r: r.status_code == 429,
+                      max_tries = 5, 
+                      vale=lambda r: int(r.headers.get("Retry-After")), 
+                      jitter=None)
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException),
                       max_tries=5,

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -251,7 +251,7 @@ def get_start(entity):
 @backoff.on_predicate(backoff.runtime,
                       predicate=lambda r: r.status_code == 429,
                       max_tries = 5, 
-                      vale=lambda r: int(r.headers.get("Retry-After")), 
+                      value=lambda r: int(r.headers.get("Retry-After")), 
                       jitter=None)
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException),

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -248,11 +248,11 @@ def get_start(entity):
         STATE[entity] = CONFIG['start_date']
     return STATE[entity]
 
-
+@backoff.on_predicate(backoff.runtime,  predicate=lambda r: r.status_code == 429, vale=lambda r: int(r.headers.get("Retry-After")), jitter=None)
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException),
                       max_tries=5,
-                      giveup=lambda e: e.response is not None and 400 <= e.response.status_code < 500, # pylint: disable=line-too-long
+                      giveup=lambda e: e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500, # pylint: disable=line-too-long
                       factor=2)
 def request(url, params=None):
     params = params or {}

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -250,7 +250,7 @@ def get_start(entity):
 
 @backoff.on_predicate(backoff.runtime,
                       predicate=lambda r: r.status_code == 429,
-                      max_tries = 5, 
+                      max_tries=5, 
                       value=lambda r: int(r.headers.get("Retry-After")), 
                       jitter=None)
 @backoff.on_exception(backoff.expo,


### PR DESCRIPTION
## Description

This MR aims to cover the case HTTP `429`  "Too Many Requests" ([RFC685](https://www.rfc-editor.org/rfc/rfc6585#section-4))i n a more specific way rather than the current way to handle any exception between the HTTP status code 400 and 500. This is motivated by the issue opened by @kgpayne [here](https://github.com/MeltanoLabs/tap-gitlab/issues/94).

## Implementation

The first decorator to be executed and added on top will be only evaluated when the HTTP code is 429 and then backoff whatever time is in the `Retry-After` header that gitlab returns (see [here](https://docs.gitlab.com/ee/administration/settings/user_and_ip_rate_limits.html#response-headers)).
The example is literally an implementation of the example supplied in the README.md from the backoff library [here](https://github.com/litl/backoff?tab=readme-ov-file#backoffruntime) + adding the same amount of max_times.

